### PR TITLE
move middleware logic to own class

### DIFF
--- a/lib/rack/attack/recaptcha.rb
+++ b/lib/rack/attack/recaptcha.rb
@@ -3,29 +3,14 @@ require "rack/attack/recaptcha/version"
 require "rack/attack/recaptcha/client_helper"
 require "rack/attack/recaptcha/verification_helper"
 require "rack/attack/recaptcha/rails"
+require "rack/attack/recaptcha/middleware"
 
 module Rack
   class Attack
     module Recaptcha
       class << self
         def new(app)
-          @default_response = Rack::Attack.throttled_response
-          @rack_attack = Rack::Attack.new(app).tap { |attack|
-            attack.class.throttled_response = lambda { |env|
-              if env["rack.attack.match_type"] == :recaptcha
-                env["rack.attack.use_recaptcha"] = true
-                app
-              else
-                @default_response
-              end.call(env)
-            }
-          }
-
-          self
-        end
-
-        def call(env)
-          @rack_attack.call(env)
+          Rack::Attack::Recaptcha::Middleware.new(app)
         end
       end
     end

--- a/lib/rack/attack/recaptcha/middleware.rb
+++ b/lib/rack/attack/recaptcha/middleware.rb
@@ -1,0 +1,25 @@
+module Rack
+  class Attack
+    module Recaptcha
+      class Middleware
+        def initialize(app)
+          @default_response = Rack::Attack.throttled_response
+          @rack_attack = Rack::Attack.new(app).tap do |attack|
+            attack.class.throttled_response = lambda do |env|
+              if env["rack.attack.match_type"] == :recaptcha
+                env["rack.attack.use_recaptcha"] = true
+                app
+              else
+                @default_response
+              end.call(env)
+            end
+          end
+        end
+
+        def call(env)
+          @rack_attack.call(env)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Setting instance variables on a class can cause unexpected issues in test environments or other situations in which multiple middleware stacks are created. Creating instances instead will ensure that this state does not escape its intended context.
